### PR TITLE
Update on DQA documentation and bug fix

### DIFF
--- a/slik_wrangler/dqa.py
+++ b/slik_wrangler/dqa.py
@@ -1,30 +1,27 @@
 """
-High level support for performing assessment on the quality of datasets
+Module for Asseting the Data Quality
 """
 
 import numpy as np
 
 from .messages import log
-from .preprocessing import check_nan
+from .utils import print_divider
+from .preprocessing import check_nan, get_attributes
 
 from IPython.display import display
 
 
 def missing_value_assessment(dataframe, display_findings=True):
     """
-    Performs assessment of missing values in a dataframe.
+    Checks the missing values from the given datset and generates
+    a report of its findings.
     
-    Function performs an assessment of the missing values from any given dataframe 
-    and generates a report of its findings if requested.
-    
-    Parameters:
-    ------------
-    dataframe: Pandas Dataframe
-        This is the dataset to be evaluated for missing values.
+    dataframe: pandas Dataframe
+        Data set to perform assessment on.
         
     display_findings: boolean, Default True
         Whether or not to display a dataframe highlighting
-        the missing values and percentage of missing values.
+        the missing values count and percentage.
     """
     
     check_nan(dataframe, display_inline=False)
@@ -47,25 +44,21 @@ def missing_value_assessment(dataframe, display_findings=True):
 
 def duplicate_assessment(dataframe, display_findings=True):
     """
-    Performs assessment of duplicate values in a dataframe.
+    Checks the duplicate values from the given datset and generates
+    a report of its findings. It does this assessment for both rows
+    and feature columns.
     
-    Function performs an assessment of the duplicate values from any given dataframe 
-    and generates a report of its findings if requested. It does this assessment for 
-    both rows and feature columns.
-    
-    Parameters:
-    ------------
     dataframe: pandas Dataframe
-        This is the dataset to be evaluated for duplicate values.
+        Data set to perform assessment on.
         
     display_findings: boolean, Default True
         Whether or not to display a dataframe highlighting
-        the duplicated row and columns.
+        the missing values count and percentage.
     """
     
     def check_duplicate_columns(df):
         """
-        Checks for all the duplicates columns in the dataset
+        Checks for all the duplicates rows in the dataset
         """
         
         duplicated = set()
@@ -73,7 +66,7 @@ def duplicate_assessment(dataframe, display_findings=True):
         
         def check(col1, col2):
             """
-            Checks if the two columns are identical
+            Checks the equality between columns
             """
             
             col1, col2 = list(map(
@@ -118,30 +111,68 @@ def duplicate_assessment(dataframe, display_findings=True):
     
     if not len(duplicated_rows) and not len(duplicated_columns):
         log("No duplicate values in both rows and columns!!!", code='success')
-
-
-def structure_assessement(dataframe, display_findings=True):
+        
+        
+def outliers_assessment(dataframe, display_findings=True):
     """
-    Checks the data structure of each feature column.
+    Checks for outliers in the given datset and generates
+    a report of its findings.
     
-    Function checks if the data type of each feature column is consistent.
-    e.g. if there is an interger variable and a string variable within a
-    feature column or more.
-    
-    For categorical columns. Assessment is conducted on similar categories
-    e.g. medium and Medium are the same and one have to be changed 
-    for the other, so it is either medium or Medium.
-    
-    This errors are mainly generated during data collection.
-    
-    Parameters:
-    ------------
     dataframe: pandas Dataframe
-        This is the dataset to be evaluated for consistent data type.
+        Data set to perform assessment on.
         
     display_findings: boolean, Default True
         Whether or not to display a dataframe highlighting
-        the feature columns with poor structures.
+        the missing values count and percentage.
+    """
+    
+    num_attributes, _ = get_attributes(dataframe)
+    
+    def contains_outliers(column):
+        """
+        Checks if the given column contains outliers
+        """
+        
+        dataframe.loc[:,column] = abs(dataframe[column])
+        
+        q25 = np.percentile(dataframe[column].dropna(), 25)
+        q75 = np.percentile(dataframe[column].dropna(), 75)
+
+        outlier_cut_off = ((q75 - q25) * 1.5)
+        lower_bound, upper_bound = (q25 - outlier_cut_off), (q75 + outlier_cut_off)
+
+        outlier_list_col = dataframe[column][(dataframe[column] < lower_bound) | (dataframe[column] > upper_bound)].index
+        
+        return bool(len(outlier_list_col))
+    
+    contains_outliers = [column for column in num_attributes if contains_outliers(column)]
+    
+    if len(contains_outliers):
+        log(
+            f"Ignore if target column is considered an outlier\n",
+            code="info"
+        )
+        log(
+            f"Dataframe contains outliers that you should address. \n\ncolumns={contains_outliers}\n", 
+            code='warning'
+        )
+        
+        if display_findings:
+            display(dataframe[contains_outliers].head())
+    else:
+        log("No outliers in dataset!!!", code='success')
+
+
+def consistent_structure_assessement(dataframe, display_findings=True):
+    """
+    Checks the consitent nature of each feature column.
+    
+    It checks if the dtype across each feature column is consistent.
+    i.e. if there is an interger variable and a string variable across
+    the various feature columns.
+    
+    For categorical columns. assessment is made on duplicate categories
+    i.e. medium and Medium are the same categories and inconsistent.
     """
     
     column_names = list(dataframe.columns)
@@ -149,7 +180,7 @@ def structure_assessement(dataframe, display_findings=True):
     
     def check_consistent_in_type(_col):
         """
-        Checks for consistency in the data type
+        Checks for consistency in the dtype
         """
         
         return all([type(c) == _col.dtype for c in _col.to_numpy()])
@@ -157,6 +188,8 @@ def structure_assessement(dataframe, display_findings=True):
     def check_consistent_in_categories(_col):
         """
         Checks for consistency in the categories
+        
+        For categorical columns
         """
         
         unique_str_cat = [c for c in _col.unique() if type(c) == str]
@@ -198,29 +231,20 @@ def structure_assessement(dataframe, display_findings=True):
 
 def data_cleanness_assessment(dataframe, display_findings=True):
     """
-    Checks for the overall cleanness of the dataframe by:
+    Checks for the overall cleanness of the dataframe:
     
-    1. Checking if there are missing values in the dataset (dataframe)
-    2. Checking if the dataset (dataframe) contains any duplicates
-    3. checking if there are any poor structure among feature columns
+    1. Checks if there are missing values in the dataset
+    2. Checks if the dataset set contains any duplicates
+    3. checks if there are any inconsistent feature columns
     
-    and finally a report is generated based on it's findings if requested
-    
-    Parameters:
-    ------------
-    dataframe: pandas Dataframe
-        This is the dataset to be evaluated on how clean it is.
-        
-    display_findings: boolean, Default True
-        Whether or not to display dataframes highlighting
-        the observations from checking for missing values, 
-        duplicate values and poor structures.
+    Gives a report.
     """
     
     issue_checker = {
         'missing values': missing_value_assessment,
         'duplicate variables': duplicate_assessment,
-        'poor structure': structure_assessement
+        'outliers': outliers_assessment,
+        'inconsistent values': consistent_structure_assessement
     }
     
     for issue in issue_checker.keys():

--- a/slik_wrangler/dqa.py
+++ b/slik_wrangler/dqa.py
@@ -1,11 +1,10 @@
 """
-Module for Asseting the Data Quality
+High level support for performing assessment on the quality of datasets
 """
 
 import numpy as np
 
 from .messages import log
-from .utils import print_divider
 from .preprocessing import check_nan
 
 from IPython.display import display
@@ -13,15 +12,19 @@ from IPython.display import display
 
 def missing_value_assessment(dataframe, display_findings=True):
     """
-    Assets the missing values from the given datset and generates
-    a report of its findings.
+    Performs assessment of missing values in a dataframe.
     
-    dataframe: pandas Dataframe
-        Data set to perform assessment on.
+    Function performs an assessment of the missing values from any given dataframe 
+    and generates a report of its findings if requested.
+    
+    Parameters:
+    ------------
+    dataframe: Pandas Dataframe
+        This is the dataset to be evaluated for missing values.
         
     display_findings: boolean, Default True
         Whether or not to display a dataframe highlighting
-        the missing values count and percentage.
+        the missing values and percentage of missing values.
     """
     
     check_nan(dataframe, display_inline=False)
@@ -44,21 +47,25 @@ def missing_value_assessment(dataframe, display_findings=True):
 
 def duplicate_assessment(dataframe, display_findings=True):
     """
-    Assets the duplicate values from the given datset and generates
-    a report of its findings. It does this assessment for both rows
-    and feature columns.
+    Performs assessment of duplicate values in a dataframe.
     
+    Function performs an assessment of the duplicate values from any given dataframe 
+    and generates a report of its findings if requested. It does this assessment for 
+    both rows and feature columns.
+    
+    Parameters:
+    ------------
     dataframe: pandas Dataframe
-        Data set to perform assessment on.
+        This is the dataset to be evaluated for duplicate values.
         
     display_findings: boolean, Default True
         Whether or not to display a dataframe highlighting
-        the missing values count and percentage.
+        the duplicated row and columns.
     """
     
     def check_duplicate_columns(df):
         """
-        Checks for all the duplicates rows in the dataset
+        Checks for all the duplicates columns in the dataset
         """
         
         duplicated = set()
@@ -66,7 +73,7 @@ def duplicate_assessment(dataframe, display_findings=True):
         
         def check(col1, col2):
             """
-            Checks the equality between columns
+            Checks if the two columns are identical
             """
             
             col1, col2 = list(map(
@@ -113,16 +120,28 @@ def duplicate_assessment(dataframe, display_findings=True):
         log("No duplicate values in both rows and columns!!!", code='success')
 
 
-def consistent_structure_assessement(dataframe, display_findings=True):
+def structure_assessement(dataframe, display_findings=True):
     """
-    Checks the consitent nature of each feature column.
+    Checks the data structure of each feature column.
     
-    It checks if the dtype across each feature column is consistent.
-    i.e. if there is an interger variable and a string variable across
-    the various feature columns.
+    Function checks if the data type of each feature column is consistent.
+    e.g. if there is an interger variable and a string variable within a
+    feature column or more.
     
-    For categorical columns. assessment is made on duplicate categories
-    i.e. medium and Medium are the same categories and inconsistent.
+    For categorical columns. Assessment is conducted on similar categories
+    e.g. medium and Medium are the same and one have to be changed 
+    for the other, so it is either medium or Medium.
+    
+    This errors are mainly generated during data collection.
+    
+    Parameters:
+    ------------
+    dataframe: pandas Dataframe
+        This is the dataset to be evaluated for consistent data type.
+        
+    display_findings: boolean, Default True
+        Whether or not to display a dataframe highlighting
+        the feature columns with poor structures.
     """
     
     column_names = list(dataframe.columns)
@@ -130,7 +149,7 @@ def consistent_structure_assessement(dataframe, display_findings=True):
     
     def check_consistent_in_type(_col):
         """
-        Checks for consistency in the dtype
+        Checks for consistency in the data type
         """
         
         return all([type(c) == _col.dtype for c in _col.to_numpy()])
@@ -138,8 +157,6 @@ def consistent_structure_assessement(dataframe, display_findings=True):
     def check_consistent_in_categories(_col):
         """
         Checks for consistency in the categories
-        
-        For categorical columns
         """
         
         unique_str_cat = [c for c in _col.unique() if type(c) == str]
@@ -181,19 +198,29 @@ def consistent_structure_assessement(dataframe, display_findings=True):
 
 def data_cleanness_assessment(dataframe, display_findings=True):
     """
-    Checks for the overall cleanness of the dataframe:
+    Checks for the overall cleanness of the dataframe by:
     
-    1. Checks if there are missing values in the dataset
-    2. Checks if the dataset set contains any duplicates
-    3. checks if there are any inconsistent feature columns
+    1. Checking if there are missing values in the dataset (dataframe)
+    2. Checking if the dataset (dataframe) contains any duplicates
+    3. checking if there are any poor structure among feature columns
     
-    Gives a report.
+    and finally a report is generated based on it's findings if requested
+    
+    Parameters:
+    ------------
+    dataframe: pandas Dataframe
+        This is the dataset to be evaluated on how clean it is.
+        
+    display_findings: boolean, Default True
+        Whether or not to display dataframes highlighting
+        the observations from checking for missing values, 
+        duplicate values and poor structures.
     """
     
     issue_checker = {
         'missing values': missing_value_assessment,
         'duplicate variables': duplicate_assessment,
-        'inconsistent values': consistent_structure_assessement
+        'poor structure': structure_assessement
     }
     
     for issue in issue_checker.keys():

--- a/slik_wrangler/preprocessing.py
+++ b/slik_wrangler/preprocessing.py
@@ -1003,7 +1003,7 @@ def _preprocess_non_target_col(data=None,processed_data_path=None,display_inline
         data = handle_nan(dataframe=data,n=3,drop_outliers=False,display_inline=display_inline,thresh_x=1,thresh_y=99,**kwargs)
 
         for column in data.columns:
-            if 'age' in column.lower():
+            if re.search(r'(.*?)[Aa]ge$', column.lower()):
                 match = re.search(r'(.*?)[Aa]ge.*', column).group()
                 age_column = str(match)
                 data = bin_age(data,age_column)
@@ -1097,7 +1097,7 @@ def _preprocess(data=None,target_column=None,train=True,select_columns=None,\
             data = map_target(data,target_column=target_column,drop=True,display_inline=display_inline)
             prefix_name = f'transformed_{target_column}'
             for column in data.columns:
-                if 'age' in column.lower():
+                if re.search(r'(.*?)[Aa]ge$', column.lower()):
                     print_divider('Bucketize Age columns')
                     print(f' Inferred age column: [{column}]')
                     match = re.search(r'(.*?)[Aa]ge.*', column).group()


### PR DESCRIPTION
@Sensei-akin, @Justus-coded, @AdesholaAfolabi 

Updated the DQA documentation so it is more descriptive.

Also found a bug in `preprocessing.preprocess`. There would always be a clash if any feature column has age contained within it.

### Error

```commandline
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-24-410f60d92945> in <module>
----> 1 pp.preprocess(dataset, target_column='SalePrice', project_path='example/')

~\anaconda3\lib\site-packages\slik_wrangler\preprocessing.py in preprocess(data, target_column, train, select_columns, display_inline, project_path, **kwargs)
   1199 
   1200     if display_inline:
-> 1201         _preprocess(data=data,target_column=target_column,train=train,select_columns=select_columns,\
   1202                display_inline=display_inline,project_path=project_path,**kwargs)
   1203     else:

~\anaconda3\lib\site-packages\slik_wrangler\preprocessing.py in _preprocess(data, target_column, train, select_columns, display_inline, project_path, **kwargs)
   1162     else:
   1163         PROCESSED_TEST_PATH = os.path.join(project_path, 'validation_data.pkl')
-> 1164         _preprocess_non_target_col(data=train_df,PROCESSED_DATA_PATH = PROCESSED_TEST_PATH,display_inline=display_inline,\
   1165                                  select_columns=select_columns,**kwargs)
   1166 

~\anaconda3\lib\site-packages\slik_wrangler\preprocessing.py in _preprocess_non_target_col(data, processed_data_path, display_inline, select_columns, **kwargs)
   1007                 match = re.search(r'(.*?)[Aa]ge.*', column).group()
   1008                 age_column = str(match)
-> 1009                 data = bin_age(data,age_column)
   1010 
   1011         for name, dtype in data.dtypes.iteritems():

~\anaconda3\lib\site-packages\slik_wrangler\preprocessing.py in bin_age(dataframe, age_col, add_prefix)
     52 
     53     bin_labels = ['Toddler/Baby', 'Child', 'Young Adult', 'Mid-Age', 'Elderly']
---> 54     data[prefix_name] = pd.cut(data[age_col], bins = [0,2,17,30,45,99], labels = bin_labels)
     55     data[prefix_name] = data[prefix_name].astype(str)
     56     return data

~\anaconda3\lib\site-packages\pandas\core\reshape\tile.py in cut(x, bins, right, labels, retbins, precision, include_lowest, duplicates, ordered)
    271             raise ValueError("bins must increase monotonically.")
    272 
--> 273     fac, bins = _bins_to_cuts(
    274         x,
    275         bins,

~\anaconda3\lib\site-packages\pandas\core\reshape\tile.py in _bins_to_cuts(x, bins, right, labels, precision, include_lowest, dtype, duplicates, ordered)
    405 
    406     side = "left" if right else "right"
--> 407     ids = ensure_int64(bins.searchsorted(x, side=side))
    408 
    409     if include_lowest:

TypeError: '<' not supported between instances of 'int' and 'str'
```

### Step to replicate

dataset: https://www.kaggle.com/competitions/house-prices-advanced-regression-techniques/data

```python
import re
from slik_wrangler.loadfile import read_file
from slik_wrangler import preprocessing as pp

dataset = read_file(train_file_path, index_col='Id')
pp.preprocess(dataset, target_column='SalePrice', project_path='.')
```

### Cause of Issue

```python
match = [c for c in dataset.columns if re.search(r'(.*?)[Aa]ge.*', c)]
print(match)
```

```commandline
['GarageType',
 'GarageYrBlt',
 'GarageFinish',
 'GarageCars',
 'GarageArea',
 'GarageQual',
 'GarageCond']
```

I wrote this all down because I wasn't the author of the function and don't know the effect of my fix.