### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Slik-wrangler has several tools that make it easy to load data of any format, cl
 
 This library is in very active development, so it’s not recommended for production use.
 
-- 📖 [Documentation](https://sensei-akin.github.io/slik_python_package/html/index.html)
+- 📖 [Documentation](https://slik-ml.github.io/slik-ml/html/index.html)
 - 🐞 [Issue Tracker](https://github.com/AdesholaAfolabi/slik_python_package/issues) - Report bugs or suggest new features
 
 


### PR DESCRIPTION
This PR addresses where our documentation in the main repository is pointed. It now points to the slik-ml docs page.